### PR TITLE
ImageCard 컴포넌트 리팩토링 및 기능 수정

### DIFF
--- a/src/components/ImageCard/ImageCard.tsx
+++ b/src/components/ImageCard/ImageCard.tsx
@@ -4,13 +4,7 @@ import { useInView } from 'react-intersection-observer';
 
 // components
 import { Picture, Video } from '@/components';
-import {
-  IMAGECARD_UNIFORM_HEIGHT__PX,
-  StyledArticle,
-  StyledDiv,
-  StyledExtraData,
-  StyledFooter,
-} from './ImageCard.styled';
+import { IMAGECARD_UNIFORM_HEIGHT__PX, StyledArticle, StyledExtraData, StyledFooter } from './ImageCard.styled';
 import { ImageCardProps } from './ImageCard.type';
 
 // SVG
@@ -26,7 +20,6 @@ export default function ImageCard({
   imageCardWidth,
   imageCardHeight,
   layoutOption,
-  isLazyLoading,
 }: ImageCardProps): ReactElement {
   const { id, thumbnailImageId, title, upCount, downCount, commentCount, views, type, hasSound, isAlbum, imageCount } =
     postInfo;
@@ -46,7 +39,6 @@ export default function ImageCard({
       `}
     >
       <StyledArticle imageCardWidth={imageCardWidth} ref={ref}>
-        {/* <StyledDiv layoutOption={layoutOption}> */}
         {!isAutoPlay || type === 'image/jpeg' || type === 'image/png' ? (
           <Picture
             alt=""
@@ -57,9 +49,13 @@ export default function ImageCard({
             inView={inView}
           />
         ) : (
-          <Video imageId={thumbnailImageId} inView={inView} />
+          <Video
+            objectFit="cover"
+            imageHeight={layoutOption === 'uniform' ? 150 : imageCardHeight}
+            imageId={thumbnailImageId}
+            inView={inView}
+          />
         )}
-        {/* </StyledDiv> */}
         <StyledExtraData>
           {imageCount > 1 && (
             <strong>

--- a/src/components/ImageCard/ImageCard.tsx
+++ b/src/components/ImageCard/ImageCard.tsx
@@ -4,7 +4,13 @@ import { useInView } from 'react-intersection-observer';
 
 // components
 import { Picture, Video } from '@/components';
-import { StyledArticle, StyledDiv, StyledExtraData, StyledFooter } from './ImageCard.styled';
+import {
+  IMAGECARD_UNIFORM_HEIGHT__PX,
+  StyledArticle,
+  StyledDiv,
+  StyledExtraData,
+  StyledFooter,
+} from './ImageCard.styled';
 import { ImageCardProps } from './ImageCard.type';
 
 // SVG
@@ -40,20 +46,20 @@ export default function ImageCard({
       `}
     >
       <StyledArticle imageCardWidth={imageCardWidth} ref={ref}>
-        <StyledDiv layoutOption={layoutOption}>
-          {!isAutoPlay || type === 'image/jpeg' || type === 'image/png' ? (
-            <Picture
-              alt=""
-              objectFit="cover"
-              imageWidth={imageCardWidth}
-              imageHeight={imageCardHeight}
-              imageId={thumbnailImageId}
-              inView={inView}
-            />
-          ) : (
-            <Video imageId={thumbnailImageId} inView={inView} />
-          )}
-        </StyledDiv>
+        {/* <StyledDiv layoutOption={layoutOption}> */}
+        {!isAutoPlay || type === 'image/jpeg' || type === 'image/png' ? (
+          <Picture
+            alt=""
+            objectFit="cover"
+            imageWidth={imageCardWidth}
+            imageHeight={layoutOption === 'uniform' ? 150 : imageCardHeight}
+            imageId={thumbnailImageId}
+            inView={inView}
+          />
+        ) : (
+          <Video imageId={thumbnailImageId} inView={inView} />
+        )}
+        {/* </StyledDiv> */}
         <StyledExtraData>
           {imageCount > 1 && (
             <strong>

--- a/src/components/ImageCard/ImageCard.tsx
+++ b/src/components/ImageCard/ImageCard.tsx
@@ -44,14 +44,14 @@ export default function ImageCard({
             alt=""
             objectFit="cover"
             imageWidth={imageCardWidth}
-            imageHeight={layoutOption === 'uniform' ? 150 : imageCardHeight}
+            imageHeight={layoutOption === 'uniform' ? IMAGECARD_UNIFORM_HEIGHT__PX - 70 : imageCardHeight}
             imageId={thumbnailImageId}
             inView={inView}
           />
         ) : (
           <Video
             objectFit="cover"
-            imageHeight={layoutOption === 'uniform' ? 150 : imageCardHeight}
+            imageHeight={layoutOption === 'uniform' ? IMAGECARD_UNIFORM_HEIGHT__PX - 70 : imageCardHeight}
             imageId={thumbnailImageId}
             inView={inView}
           />

--- a/src/components/Video/Video.styled.tsx
+++ b/src/components/Video/Video.styled.tsx
@@ -1,0 +1,14 @@
+import { pxToRem } from '@/util/styleUtils';
+import styled from 'styled-components';
+import { StyledVideoProps } from './Video.type';
+
+export const StyledVideo = styled.video.attrs<StyledVideoProps>(({ imageHeight, objectFit }) => {
+  return {
+    style: {
+      height: pxToRem(imageHeight),
+      objectFit: objectFit,
+    },
+  };
+})<StyledVideoProps>`
+  width: 100%;
+`;

--- a/src/components/Video/Video.tsx
+++ b/src/components/Video/Video.tsx
@@ -1,15 +1,33 @@
+import { pxToRem } from '@/util/styleUtils';
 import React, { ReactElement } from 'react';
 import { VideoProps } from './Video.type';
+import { StyledVideo } from './Video.styled';
 
-export default function Video({ className, controls, imageId, inView = true }: VideoProps): ReactElement {
+export default function Video({
+  className,
+  controls,
+  imageId,
+  objectFit,
+  imageHeight,
+  inView = true,
+}: VideoProps): ReactElement {
   const src = `https://i.imgur.com/${imageId}_lq.mp4`;
 
   return (
     inView && (
-      <video controls={controls} className={className} autoPlay loop muted playsInline width="100%">
+      <StyledVideo
+        imageHeight={imageHeight}
+        objectFit={objectFit}
+        controls={controls}
+        className={className}
+        autoPlay
+        loop
+        muted
+        playsInline
+      >
         <source data-src={!inView ? src : null} src={inView ? src : null} />
         <p>Sorry, your browser doesn&#39;t support HTML5 videos.</p>
-      </video>
+      </StyledVideo>
     )
   );
 }

--- a/src/components/Video/Video.type.ts
+++ b/src/components/Video/Video.type.ts
@@ -1,4 +1,10 @@
-export interface VideoProps {
+export interface StyledVideoProps {
+  imageWidth?: string | number;
+  imageHeight?: string | number;
+  objectFit?: 'contain' | 'cover' | 'fill' | 'none' | 'scale-down';
+}
+
+export interface VideoProps extends StyledVideoProps {
   imageId: string;
   className?: string;
   controls?: boolean;


### PR DESCRIPTION
- object-fit 속성을 사용하는데 불필요하게 사용되던 div를 제거 
  - ImageCard 컴포넌트에서 img 혹은 video를 감싸던 div 제거
- #121
  - object-fit: contain으로 설정되어있던 video를 object-fit: cover로 수정하여 해결
- #218-  